### PR TITLE
グループ登録フォームにIDチェックを追加

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -90,4 +90,25 @@ $(document).on('turbolinks:load', function(){
     });
 });
 
+// グループ新規登録時のIDチェック
+$(document).on('turbolinks:load', function(){
+    $(document).on('keyup', '#group-self-id', function(e){
+        e.preventDefault();
+        var input = $.trim($(this).val());
+        $.ajax({
+            url: '/groups',
+            type: 'GET',
+            data: ('keyword=' + input),
+            processData: false,
+            contentType: false,
+            dataType: 'json'
+        })
+        .done(function(data){
+            $('#result').find('p').remove();
+            $(data).show(function(){
+                $('#result').append('<p style="color: red;">' + '既に使われています' + '</p>')
+            });
+        })
+    });
+});
 

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -5,6 +5,10 @@ class GroupsController < ApplicationController
   def index
   	@new_group = Group.new
     @waiting_for_allows = GroupUser.where(user_id: current_user.id, join_status: "waiting_for_allow")
+    @self_id = Group.find_by(self_id: params[:keyword])
+    if params[:keyword].present?
+      render json: @self_id.as_json(only: [:self_id])
+    end
   end
 
   def create
@@ -21,7 +25,7 @@ class GroupsController < ApplicationController
     else
       @new_group = Group.new
       @request = params[:request]
-      flash.now[:alert] = "既に使われています"
+      flash.now[:alert] = "別のIDで登録して下さい"
       render action: :index
     end
   end

--- a/app/views/groups/index.html.erb
+++ b/app/views/groups/index.html.erb
@@ -34,6 +34,7 @@
 	<div class="col-lg-3 pr-1 pl-1">
 		<div>
 			<h4 class="text-center border-bottom"><i class="fas fa-child"></i><i class="fas fa-child"></i>グループ追加<i class="fas fa-child"></i><i class="fas fa-child"></i></h4>
+			<p style="color: red;"><%= alert %></p>
 			<%= form_for @new_group do |f| %>
 
 				<%= f.label :image, "グループのサムネイル" %><i class="fas fa-camera"></i>
@@ -44,8 +45,9 @@
 				<%= f.text_field :name, class: "form form-control", placeholder: "グループ名", required: true %>
 
 				<%= f.label :self_id, :グループID %>
-				<%= f.text_field :self_id, class: "form form-control", placeholder: "グループID(任意)" %>
-				<p style="color: red;"><%= alert %></p>
+				<%= f.text_field :self_id, class: "form form-control", placeholder: "グループID(任意)", id: "group-self-id" %>
+				<div id="result">
+				</div>
 				<%= f.radio_button :private_status, "closed", checked: "checked" %>
 				<%= f.label :private_status, "検索不可にする" %>
 				<br>


### PR DESCRIPTION
グループの新規登録フォームのID入力時に既に使われているかどうかをチェックできる機能の実装